### PR TITLE
Add error checks for addLoan

### DIFF
--- a/src/main/java/bookkeeper/InputHandler.java
+++ b/src/main/java/bookkeeper/InputHandler.java
@@ -64,6 +64,10 @@ public class InputHandler {
      * @param commandArgs The parsed command arguments.
      */
     private void addLoan(String[] commandArgs) {
+        if (commandArgs.length < 2) {
+            throw new IllegalArgumentException("Invalid format for add-loan. " +
+                    "Expected format: add-loan BOOK_TITLE n/BORROWER_NAME d/RETURN_DATE");
+        }
         try {
             String[] loanArgs = InputParser.extractAddLoanArgs(commandArgs[1]);
             Book loanedBook = bookList.findBookByTitle(loanArgs[0]);

--- a/src/main/java/bookkeeper/InputParser.java
+++ b/src/main/java/bookkeeper/InputParser.java
@@ -47,11 +47,22 @@ public class InputParser {
      * @throws IllegalArgumentException if the input format is invalid.
      */
     public static String[] extractAddLoanArgs(String input) {
+        String[] commandArgs = new String[3];
+
         String[] splitInput = input.trim().split("( n/)|( d/)", 3);
-        if (splitInput.length < 3) {
+        if (splitInput.length != 3) {
             throw new IllegalArgumentException("Invalid format for add-loan. " +
                     "Expected format: add-loan BOOK_TITLE n/BORROWER_NAME d/RETURN_DATE");
         }
-        return splitInput;
+
+        for (int i = 0; i < splitInput.length; i++) {
+            if(splitInput[i].isBlank()){
+                throw new IllegalArgumentException("Invalid format for add-loan. " +
+                    "Expected format: add-loan BOOK_TITLE n/BORROWER_NAME d/RETURN_DATE");
+            }
+            commandArgs[i] = splitInput[i].trim();
+        }
+
+        return commandArgs;
     }
 }


### PR DESCRIPTION
Add guard clauses for improper user input cases:
  1. `addLoan`
  2. `addLoan title n/ d/` (blank borrower or date)