### PR TITLE
Add optional note attribute for Book

### DIFF
--- a/src/main/java/bookkeeper/Book.java
+++ b/src/main/java/bookkeeper/Book.java
@@ -6,13 +6,21 @@ public class Book {
     private String category;
     private String condition;
     private boolean onLoan;
+    private String note;
 
+    // Constructor with optional note
     public Book(String title, String author, String category, String condition) {
+        this(title, author, category, condition, ""); // Default note is an empty string
+    }
+
+    // Constructor with note
+    public Book(String title, String author, String category, String condition, String note) {
         this.title = title;
         this.author = author;
         this.category = category;
         this.condition = condition;
-        onLoan = false;
+        this.note = note;
+        this.onLoan = false;
     }
 
     public String getTitle() {
@@ -35,6 +43,10 @@ public class Book {
         return onLoan;
     }
 
+    public String getNote() {
+        return note;
+    }
+
     public void setOnLoan(boolean onLoan) {
         this.onLoan = onLoan;
     }
@@ -45,6 +57,7 @@ public class Book {
                 + "    Author: " + getAuthor() + System.lineSeparator()
                 + "    Category: " + getCategory() + System.lineSeparator()
                 + "    Condition: " + getCondition() + System.lineSeparator()
-                + "    On Loan: " + getOnLoan();
+                + "    On Loan: " + getOnLoan() + System.lineSeparator()
+                + "    Note: " + (note.isEmpty() ? "No notes available" : note);
     }
 }

--- a/src/main/java/bookkeeper/Book.java
+++ b/src/main/java/bookkeeper/Book.java
@@ -58,6 +58,6 @@ public class Book {
                 + "    Category: " + getCategory() + System.lineSeparator()
                 + "    Condition: " + getCondition() + System.lineSeparator()
                 + "    On Loan: " + getOnLoan() + System.lineSeparator()
-                + "    Note: " + (note.isEmpty() ? "No notes available" : note);
+                + "    Note: " + (note.isEmpty() ? "No notes available" : getNote());
     }
 }

--- a/src/main/java/bookkeeper/InputHandler.java
+++ b/src/main/java/bookkeeper/InputHandler.java
@@ -111,21 +111,25 @@ public class InputHandler {
     private void addBook(String[] commandArgs) throws IncorrectFormatException {
         if (commandArgs.length < 2) {
             throw new IncorrectFormatException("Invalid format for add-book.\n" +
-                    "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION");
+                    "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION [note/NOTES]");
         }
         String[] bookArgs = InputParser.extractAddBookArgs(commandArgs[1]);
-        assert bookArgs.length == 4 : "Book arguments should contain exactly 4 elements";
-
+        assert bookArgs.length >= 4 : "Book arguments should contain at least 4 elements";
+    
         // Trim whitespaces from the book title
         String bookTitle = bookArgs[0].trim();
-
+    
         // Check if book already exists in the inventory
         if (bookList.findBookByTitle(bookTitle) != null) {
             Formatter.printBorderedMessage("Book already exists in inventory: " + bookTitle);
             return;
         }
-
-        Book newBook = new Book(bookArgs[0], bookArgs[1], bookArgs[2], bookArgs[3]);
+    
+        // Handle optional note
+        String note = bookArgs.length == 5 ? bookArgs[4] : ""; // Default to empty string if note is not provided
+    
+        // Add the new book to the book list
+        Book newBook = new Book(bookTitle, bookArgs[1], bookArgs[2], bookArgs[3], note);
         bookList.addBook(newBook);
         Formatter.printBorderedMessage("New book added: " + newBook.getTitle());
     }

--- a/src/main/java/bookkeeper/InputParser.java
+++ b/src/main/java/bookkeeper/InputParser.java
@@ -13,23 +13,36 @@ public class InputParser {
     }
 
     public static String[] extractAddBookArgs(String input) throws IncorrectFormatException {
-        String[] commandArgs = new String[4];
+        // Split the input into required fields and optional note
         String[] splitInput = input.trim().split("( a/)|( cat/)|( cond/)", 4);
-
-        if (splitInput.length != 4) {
+    
+        if (splitInput.length < 4) {
             throw new IncorrectFormatException("Invalid format for add-book.\n" +
-                    "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION");
+                    "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION [note/NOTES]");
         }
-
-        for (int i = 0; i < splitInput.length; i++) {
-            if (splitInput[i].isBlank()) {
-                throw new IncorrectFormatException("Invalid format for add-book.\n" +
-                        "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION");
-            }
-            commandArgs[i] = splitInput[i].trim();
+    
+        // Extract required fields
+        String bookTitle = splitInput[0].trim();
+        String author = splitInput[1].trim();
+        String category = splitInput[2].trim();
+        String condition = splitInput[3].trim();
+    
+        // Check for optional note
+        String note = "";
+        if (condition.contains(" note/")) {
+            String[] conditionAndNote = condition.split(" note/", 2);
+            condition = conditionAndNote[0].trim(); // Update condition without the note
+            note = conditionAndNote.length > 1 ? conditionAndNote[1].trim() : ""; // Extract note if present
         }
-
-        return commandArgs;
+    
+        // Validate required fields
+        if (bookTitle.isBlank() || author.isBlank() || category.isBlank() || condition.isBlank()) {
+            throw new IncorrectFormatException("Invalid format for add-book.\n" +
+                    "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION [note/NOTES]");
+        }
+    
+        // Return all fields, including the optional note
+        return new String[]{bookTitle, author, category, condition, note};
     }
 
     /**

--- a/src/test/java/bookkeeper/BookListTest.java
+++ b/src/test/java/bookkeeper/BookListTest.java
@@ -2,6 +2,7 @@ package bookkeeper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/src/test/java/bookkeeper/InputParserTest.java
+++ b/src/test/java/bookkeeper/InputParserTest.java
@@ -10,55 +10,58 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InputParserTest {
 
+    // extractAddBookArgs gives us 5 arguments: name, author, category, condition, note("" if not provided)
     @Test
-    void extractAddBookArgs_validInput_fourArgumentStringArray() throws IncorrectFormatException {
+    void extractAddBookArgs_validInput_fiveArgumentStringArray() throws IncorrectFormatException {
         String[] arguments = InputParser.extractAddBookArgs("The Great Gatsby " +
                 "a/F. Scott Fitzgerald cat/Fiction cond/Good");
-        String[] output = new String[] {"The Great Gatsby", "F. Scott Fitzgerald", "Fiction", "Good"};
+        String[] output = new String[]{"The Great Gatsby", "F. Scott Fitzgerald", "Fiction", "Good", ""};
         assertArrayEquals(arguments, output);
     }
 
     @Test
-    void extractAddBookArgs_inputWithExtraSpace_fourArgumentStringArray() throws IncorrectFormatException {
+    void extractAddBookArgs_inputWithExtraSpace_fiveArgumentStringArray() throws IncorrectFormatException {
         String[] arguments = InputParser.extractAddBookArgs("The Great Gatsby " +
                 "a/F. Scott Fitzgerald    cat/Fiction cond/Good   ");
-        String[] output = new String[] {"The Great Gatsby", "F. Scott Fitzgerald", "Fiction", "Good"};
+        String[] output = new String[]{"The Great Gatsby", "F. Scott Fitzgerald", "Fiction", "Good", ""};
         assertArrayEquals(arguments, output);
     }
 
     @Test
-    void extractAddBookArgs_missingAuthor_exceptionThrown()  {
-        IncorrectFormatException exception = assertThrows(IncorrectFormatException.class, () 
+    void extractAddBookArgs_missingAuthor_exceptionThrown() {
+        IncorrectFormatException exception = assertThrows(IncorrectFormatException.class, ()
                 -> InputParser.extractAddBookArgs("The Great Gatsby cat/Fiction cond/Good"));
         assertEquals("Invalid format for add-book.\n" +
-                "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION", exception.getMessage());
+                        "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION [note/NOTES]",
+                exception.getMessage());
     }
 
     @Test
-    void extractAddBookArgs_missingBookName_exceptionThrown()  {
-        IncorrectFormatException exception = assertThrows(IncorrectFormatException.class, () 
+    void extractAddBookArgs_missingBookName_exceptionThrown() {
+        IncorrectFormatException exception = assertThrows(IncorrectFormatException.class, ()
                 -> InputParser.extractAddBookArgs("a/F. Scott Fitzgerald cat/Fiction cond/Good"));
         assertEquals("Invalid format for add-book.\n" +
-                "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION", exception.getMessage());
+                        "Expected format: add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION [note/NOTES]",
+                exception.getMessage());
     }
 
     @Test
-    void extractAddLoanArgs_validInput_threeArgumentStringArray() throws IncorrectFormatException{
+    void extractAddLoanArgs_validInput_threeArgumentStringArray() throws IncorrectFormatException {
         String[] arguments = InputParser.extractAddLoanArgs("The Great Gatsby n/Mary d/12-Mar-2025");
-        String[] output = new String[] {"The Great Gatsby", "Mary", "12-Mar-2025"};
+        String[] output = new String[]{"The Great Gatsby", "Mary", "12-Mar-2025"};
         assertArrayEquals(arguments, output);
     }
 
     @Test
-    void extractAddLoanArgs_inputWithExtraSpace_threeArgumentStringArray() throws IncorrectFormatException{
+    void extractAddLoanArgs_inputWithExtraSpace_threeArgumentStringArray() throws IncorrectFormatException {
         String[] arguments = InputParser.extractAddLoanArgs("The Great Gatsby   n/Mary d/12-Mar-2025 ");
-        String[] output = new String[] {"The Great Gatsby", "Mary", "12-Mar-2025"};
+        String[] output = new String[]{"The Great Gatsby", "Mary", "12-Mar-2025"};
         assertArrayEquals(arguments, output);
     }
 
     @Test
-    void extractAddLoanArgs_missingDate_exceptionThrown(){
-        IncorrectFormatException exception = assertThrows(IncorrectFormatException.class, () 
+    void extractAddLoanArgs_missingDate_exceptionThrown() {
+        IncorrectFormatException exception = assertThrows(IncorrectFormatException.class, ()
                 -> InputParser.extractAddLoanArgs("The Great Gatsby n/Mary"));
         assertEquals("Invalid format for add-loan.\n" +
                 "Expected format: add-loan BOOK_TITLE n/BORROWER_NAME d/RETURN_DATE", exception.getMessage());
@@ -67,7 +70,7 @@ public class InputParserTest {
     @Test
     void extractCommandArgs_validInput_twoArgumentStringArray() throws IncorrectFormatException {
         String[] arguments = InputParser.extractCommandArgs("delete-loan The Great Gatsby n/Mary");
-        String[] output = new String[] {"delete-loan", "The Great Gatsby n/Mary"};
+        String[] output = new String[]{"delete-loan", "The Great Gatsby n/Mary"};
         assertArrayEquals(arguments, output);
     }
 
@@ -77,26 +80,26 @@ public class InputParserTest {
             InputParser.extractCommandArgs("delete-loan ");
         } catch (IncorrectFormatException e) {
             assertEquals("Invalid command format.\nExpected: COMMAND [ARGUMENTS]", e.getMessage());
-        }  
+        }
     }
 
     @Test
     void extractDeleteLoanArgs_validInput_twoArgumentArray() throws IncorrectFormatException {
         String[] arguments = InputParser.extractDeleteLoanArgs("The Great Gatsby n/Mary");
-        String[] output = new String[] {"The Great Gatsby", "Mary"};
-        assertArrayEquals(arguments, output);        
+        String[] output = new String[]{"The Great Gatsby", "Mary"};
+        assertArrayEquals(arguments, output);
     }
 
     @Test
     void extractDeleteLoanArgs_inputWithExtraSpace_twoArgumentArray() throws IncorrectFormatException {
         String[] arguments = InputParser.extractDeleteLoanArgs("The Great Gatsby   n/Mary  ");
-        String[] output = new String[] {"The Great Gatsby", "Mary"};
-        assertArrayEquals(arguments, output);        
+        String[] output = new String[]{"The Great Gatsby", "Mary"};
+        assertArrayEquals(arguments, output);
     }
 
     @Test
-    void extractDeleteLoanArgs_missingArguments_exceptionThrown(){
-        IncorrectFormatException exception = assertThrows(IncorrectFormatException.class, () 
+    void extractDeleteLoanArgs_missingArguments_exceptionThrown() {
+        IncorrectFormatException exception = assertThrows(IncorrectFormatException.class, ()
                 -> InputParser.extractDeleteLoanArgs("The Great Gatsby"));
         assertEquals("Invalid format for delete-loan.\n" +
                 "Expected format: delete-loan BOOK_TITLE n/BORROWER_NAME", exception.getMessage());

--- a/src/test/java/bookkeeper/LoanListTest.java
+++ b/src/test/java/bookkeeper/LoanListTest.java
@@ -47,7 +47,7 @@ public class LoanListTest {
             loanList.addLoan(null);
         }, "Adding a null loan should throw an AssertionError");
 
-        assertEquals("Loan cannot be null", error.getMessage(), 
+        assertEquals("Loan cannot be null", error.getMessage(),
                 "The error message should indicate that the loan cannot be null");
     }
 


### PR DESCRIPTION
Now add-book accepts the following format:

```
add-book BOOK_TITLE a/AUTHOR cat/CATEGORY cond/CONDITION [note/NOTES]
```

Example of accepted input:
1. add-book The Great Gatsby a/F. Scott Fitzgerald cat/Fiction cond/Good
2. add-book The Great Gatsby a/F. Scott Fitzgerald cat/Fiction cond/Good note/Greatest Hit

Closes #50
Closes #55